### PR TITLE
Fixed bugs on Jetson

### DIFF
--- a/test-app/src/main.js
+++ b/test-app/src/main.js
@@ -42,7 +42,9 @@ async function initROS() {
     console.log(`Received from Jetson: ${msg.data}`);
     
     temp = "BATTERY_" + msg.data;
-    mainWindow.webContents.send('update-display', temp);
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.webContents) {
+    	mainWindow.webContents.send('update-display', temp);
+    }
   });
 
   const topic_speed = 'electron_speed';
@@ -50,7 +52,9 @@ async function initROS() {
     console.log(`Received from Jetson: ${msg.data}`);
     
     temp = "SPEED_" + msg.data;
-    mainWindow.webContents.send('update-display', temp);
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.webContents) {
+    	mainWindow.webContents.send('update-display', temp);
+    }
   });
 
   node.spin();


### PR DESCRIPTION
There were bugs with logging into the Jetson and logging out.

"TypeError: Cannot read properties of undefined (reading 'webContents') at Subscription._callback (/home/bad/Frontend/test-app/src/main.js:45:16)"

I fixed them by just putting a few checks before calling 

"mainWindow.webContents.send('update-display', temp);"

Interestingly, this bug didn't appear on either of the other machines I have run the Frontend on, only on the Jetson.